### PR TITLE
Fixed extra characters when parsing comments rows

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path')
 const recursiveReadDir = require('recursive-readdir')
 
 function parseComments(file) {
-  const lines = file.split('\n'), require = []
+  const lines = file.split(/\r?\n/), require = []
   let i = 0, dropCode = ''
 
   while(lines[i].startsWith('--') || lines[i].trim() === '') {


### PR DESCRIPTION
On windows system i faced with strange behavior, when specify comment about required entity. After debugging i found problem. This is related to \r symbol which breaks required paths. Suggested solution is remove all extra symbols in require and drop code comments